### PR TITLE
Configure Paperclip

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,9 @@ Rails.application.configure do
   # Clearance
   config.action_mailer.default_url_options = { host: "test.locahost:3000" }
   config.middleware.use Clearance::BackDoor
+
+  # Paperclip
+  Paperclip::Attachment.default_options[:path] = (
+    "#{Rails.root}/public/system/:class/:id_partition/:style.:extension"
+  )
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,4 +98,9 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  # Paperclip
+  config.after(:suite) do
+    FileUtils.rm_rf(Dir["#{Rails.root}/public/system"])
+  end
 end


### PR DESCRIPTION
Paperclip was saving multiple copies of test files after running
integration tests. To avoid this, we specify a custom path and remove
that directory after running the test suite.

https://github.com/thoughtbot/paperclip#testing