### PR TITLE
Add Clearance migration that was never committed

### DIFF
--- a/db/migrate/20170622215607_add_clearance_to_users.rb
+++ b/db/migrate/20170622215607_add_clearance_to_users.rb
@@ -1,0 +1,9 @@
+class AddClearanceToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :encrypted_password, :string, limit: 128
+    add_column :users, :confirmation_token, :string, limit: 128
+    add_column :users, :remember_token, :string, limit: 128
+    add_index :users, :email
+    add_index :users, :remember_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170621143033) do
+ActiveRecord::Schema.define(version: 20170622215607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
The commit from May 9 adding Clearance for authentication did not
include the migration adding encrypted_password, et. al. to the users
table. This commit fixes that oversight. Whoops! :grimace: