### PR TITLE
Differentiate between different types of Activity

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,11 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def record_activity(subject:)
+  def record_activity(subject:, status:)
     Activity.create!(
       subject: subject,
       user: current_user,
+      status: status,
     )
   end
 end

--- a/app/controllers/audio_files_controller.rb
+++ b/app/controllers/audio_files_controller.rb
@@ -6,7 +6,7 @@ class AudioFilesController < ApplicationController
   def create
     @audio_file = current_user.audio_files.new(audio_file_params)
     if @audio_file.save
-      record_activity(subject: @audio_file)
+      record_activity(subject: @audio_file, status: "created")
       redirect_to dashboard_url, notice: "Audio file created! You rock."
     else
       render :new, status: 400
@@ -20,7 +20,7 @@ class AudioFilesController < ApplicationController
   def update
     @audio_file = current_user.audio_files.find(params[:id])
     if @audio_file.update(audio_file_params)
-      record_activity(subject: @audio_file)
+      record_activity(subject: @audio_file, status: "updated")
       redirect_to dashboard_url, notice: "Audio file updated successfully."
     else
       render :edit, status: 400

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -6,7 +6,7 @@ class SnippetsController < ApplicationController
   def create
     @snippet = current_user.snippets.new(snippet_params)
     if @snippet.save
-      record_activity(subject: @snippet)
+      record_activity(subject: @snippet, status: "created")
       redirect_to dashboard_url, notice: "Snippet created! You rock."
     else
       render :new, status: 400
@@ -20,7 +20,7 @@ class SnippetsController < ApplicationController
   def update
     @snippet = current_user.snippets.find(params[:id])
     if @snippet.update(snippet_params)
-      record_activity(subject: @snippet)
+      record_activity(subject: @snippet, status: "updated")
       redirect_to dashboard_url, notice: "Snippet updated successfully."
     else
       render :edit, status: 400

--- a/app/controllers/wishlists_controller.rb
+++ b/app/controllers/wishlists_controller.rb
@@ -6,7 +6,7 @@ class WishlistsController < ApplicationController
   def create
     @wishlist = current_user.wishlists.new(wishlist_params)
     if @wishlist.save
-      record_activity(subject: @wishlist)
+      record_activity(subject: @wishlist, status: "created")
       redirect_to dashboard_url, notice: "Wishlist item created! You rock."
     else
       render :new, status: 400
@@ -20,7 +20,7 @@ class WishlistsController < ApplicationController
   def update
     @wishlist = current_user.wishlists.find(params[:id])
     if @wishlist.update(wishlist_params)
-      record_activity(subject: @wishlist)
+      record_activity(subject: @wishlist, status: "updated")
       redirect_to dashboard_url, notice: "Wishlist item updated successfully."
     else
       render :edit, status: 400

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,4 +1,9 @@
 class Activity < ApplicationRecord
   belongs_to :user
   belongs_to :subject, polymorphic: true
+
+  enum status: {
+    created: 0,
+    updated: 1,
+  }
 end

--- a/db/migrate/20170622221524_add_status_to_activities.rb
+++ b/db/migrate/20170622221524_add_status_to_activities.rb
@@ -1,0 +1,5 @@
+class AddStatusToActivities < ActiveRecord::Migration[5.0]
+  def change
+    add_column :activities, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170622215607) do
+ActiveRecord::Schema.define(version: 20170622221524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,8 +19,9 @@ ActiveRecord::Schema.define(version: 20170622215607) do
     t.integer  "user_id"
     t.integer  "subject_id"
     t.string   "subject_type"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.integer  "status",       default: 0, null: false
     t.index ["subject_id"], name: "index_activities_on_subject_id", using: :btree
     t.index ["subject_type"], name: "index_activities_on_subject_type", using: :btree
     t.index ["user_id"], name: "index_activities_on_user_id", using: :btree

--- a/spec/controllers/audio_files_controller_spec.rb
+++ b/spec/controllers/audio_files_controller_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe AudioFilesController do
       expect(Activity).to have_received(:create!).with(
         subject: mock_audio_file,
         user: user,
+        status: "created",
       )
     end
   end

--- a/spec/controllers/snippets_controller_spec.rb
+++ b/spec/controllers/snippets_controller_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe SnippetsController do
       expect(Activity).to have_received(:create!).with(
         subject: mock_snippet,
         user: user,
+        status: "created",
       )
     end
   end

--- a/spec/controllers/wishlists_controller_spec.rb
+++ b/spec/controllers/wishlists_controller_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe WishlistsController do
         expect(Activity).to have_received(:create!).with(
           subject: mock_wishlist,
           user: user,
+          status: "created",
         )
       end
     end
@@ -128,6 +129,7 @@ RSpec.describe WishlistsController do
         expect(Activity).to have_received(:create!).with(
           subject: wishlist,
           user: user,
+          status: "updated",
         )
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -5,4 +5,8 @@ RSpec.describe Activity do
     it { is_expected.to belong_to :user }
     it { is_expected.to belong_to :subject }
   end
+
+  describe "is enum" do
+    it { should define_enum_for(:status) }
+  end
 end


### PR DESCRIPTION
We want to be able to differentiate between different types of
activities, for example, a create vs. an update activity, and display
that difference in the UI. We add an enum status to Activity so we can
display different copy that correlates to different activities.