### PR TITLE
Add copy to view for Activity types

### DIFF
--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -2,7 +2,7 @@
 <%= activity.subject.title %>, by <%= activity.subject.artist %></h3>
 
 <p class="saved-by">
-<%= activity.subject_type.underscore.humanize %> saved by: <%= activity.user.username %></p>
+<%= activity.subject_type.underscore.humanize %> <%= activity.status %> by: <%= activity.user.username %></p>
 
 <%= render activity.subject %>
 <h3 class="snippet-info"><%= activity.created_at.to_formatted_s %></h3>

--- a/spec/features/user_creates_snippet_spec.rb
+++ b/spec/features/user_creates_snippet_spec.rb
@@ -15,6 +15,6 @@ RSpec.feature "User creates snippet" do
 
     expect(page).to have_text "#{title}, by #{artist}"
     expect(page).to have_text notes
-    expect(page).to have_text "saved by: #{user.username}"
+    expect(page).to have_text "created by: #{user.username}"
   end
 end


### PR DESCRIPTION
Display corresponding copy for Activity status on dashboard, i.e.:
"Snippet created by: Christina"
"Audio file updated by: stardude447"