### PR TITLE
Remove halt_callback_chains_on_return_false

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -17,8 +17,5 @@ ActiveSupport.to_time_preserves_timezone = true
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
-
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
Removing this line removes the RSpec deprecation warning:
ActiveSupport.halt_callback_chains_on_return_false= is deprecated and
will be removed in Rails 5.2.